### PR TITLE
[NOTICKET] remove debug print statement

### DIFF
--- a/BaseStructoriOSUIKit/BaseStructoriOSUIKit/Modules/Home/DI/HomeDIContainer.swift
+++ b/BaseStructoriOSUIKit/BaseStructoriOSUIKit/Modules/Home/DI/HomeDIContainer.swift
@@ -53,7 +53,6 @@ extension HomeDIContainer: HomeFactoryProtocol {
     
     func makeHomeViewController() -> HomeViewController {
         let viewModel = makeHomeViewModel()
-        print("test")
         return HomeViewController(viewModel: viewModel)
     }
     

--- a/BaseStructoriOSUIKit/BaseStructoriOSUIKit/Modules/Home/DI/HomeDIContainer.swift
+++ b/BaseStructoriOSUIKit/BaseStructoriOSUIKit/Modules/Home/DI/HomeDIContainer.swift
@@ -53,6 +53,7 @@ extension HomeDIContainer: HomeFactoryProtocol {
     
     func makeHomeViewController() -> HomeViewController {
         let viewModel = makeHomeViewModel()
+        print("")
         return HomeViewController(viewModel: viewModel)
     }
     


### PR DESCRIPTION
Removes a stray print statement from the HomeViewController creation. The print statement was likely used for debugging and is no longer needed.